### PR TITLE
feat: selective bloom (layer-masked) + B toggle + I quality

### DIFF
--- a/zeno-polyhedron-refactored.html
+++ b/zeno-polyhedron-refactored.html
@@ -1281,12 +1281,10 @@
             },
             vertexShader: `
               // For fullscreen quad rendering, set z=0.0 (on near plane) and w=1.0 (homogeneous coordinate)
-              #define FULLSCREEN_QUAD_Z 0.0
-              #define FULLSCREEN_QUAD_W 1.0
               varying vec2 vUv;
               void main() {
                 vUv = uv;
-                gl_Position = vec4(position.xy, FULLSCREEN_QUAD_Z, FULLSCREEN_QUAD_W);
+                gl_Position = vec4(position.xy, 0.0, 1.0);
               }
             `,
             fragmentShader: `

--- a/zeno-polyhedron-refactored.html
+++ b/zeno-polyhedron-refactored.html
@@ -1567,7 +1567,7 @@
         this.updateComposerSizes(scale);
       }
       
-      /**
+        if (!this.composer || !this.bloomComposer) {
        * Update/render post-processing
        */
       render(deltaTime) {

--- a/zeno-polyhedron-refactored.html
+++ b/zeno-polyhedron-refactored.html
@@ -1432,11 +1432,13 @@
        * Restore visibility after bloom pass
        */
       restoreHiddenObjects() {
-        this.scene.traverse((object) => {
-          if (!this.hiddenObjects.has(object.uuid)) return;
-          object.visible = this.hiddenObjects.get(object.uuid);
-          this.hiddenObjects.delete(object.uuid);
-        });
+        for (const [uuid, wasVisible] of this.hiddenObjects.entries()) {
+          const object = this.scene.getObjectByProperty('uuid', uuid);
+          if (object) {
+            object.visible = wasVisible;
+          }
+        }
+        this.hiddenObjects.clear();
       }
       
       /**

--- a/zeno-polyhedron-refactored.html
+++ b/zeno-polyhedron-refactored.html
@@ -1567,7 +1567,7 @@
         this.updateComposerSizes(scale);
       }
       
-        if (!this.composer || !this.bloomComposer) {
+       /**
        * Update/render post-processing
        */
       render(deltaTime) {

--- a/zeno-polyhedron-refactored.html
+++ b/zeno-polyhedron-refactored.html
@@ -281,7 +281,7 @@
   </div>
 
   <div class="controls">
-    Space: Pause • R: Reset • P: Performance • B: Bloom • S: Shaders • I: Quality • Shift+I: Intensity • 1-3: States
+    Space: Pause • R: Reset • P: Performance • B: Bloom • S: Shaders • I: Bloom Quality (Low/Med/High) • Shift+I: Intensity • 1-3: States
   </div>
 
   <div class="perf-monitor" id="perfMonitor">

--- a/zeno-polyhedron-refactored.html
+++ b/zeno-polyhedron-refactored.html
@@ -281,7 +281,7 @@
   </div>
 
   <div class="controls">
-    Space: Pause • R: Reset • P: Performance • B: Bloom • S: Shaders • I: Bloom Quality • Shift+I: Intensity • 1-3: States
+    Space: Pause • R: Reset • P: Performance • B: Bloom • S: Shaders • I: Quality • Shift+I: Intensity • 1-3: States
   </div>
 
   <div class="perf-monitor" id="perfMonitor">

--- a/zeno-polyhedron-refactored.html
+++ b/zeno-polyhedron-refactored.html
@@ -1358,9 +1358,11 @@
        */
       updateBloomTextureUniform() {
         if (!this.effects.compositePass || !this.bloomComposer) return;
-        const target = this.bloomComposer.renderTarget2 || this.bloomComposer.renderTarget1;
+        const target = this.bloomComposer.renderTarget2 || this.bloomComposer.renderTarget1 || null;
         if (target) {
           this.effects.compositePass.material.uniforms.bloomTexture.value = target.texture;
+        } else {
+          this.effects.compositePass.material.uniforms.bloomTexture.value = null;
         }
       }
 

--- a/zeno-polyhedron-refactored.html
+++ b/zeno-polyhedron-refactored.html
@@ -281,7 +281,7 @@
   </div>
 
   <div class="controls">
-    Space: Pause • R: Reset • P: Performance • B: Bloom • S: Shaders • I: Intensity • 1-3: States
+    Space: Pause • R: Reset • P: Performance • B: Bloom • S: Shaders • I: Bloom Quality • Shift+I: Intensity • 1-3: States
   </div>
 
   <div class="perf-monitor" id="perfMonitor">
@@ -1151,15 +1151,18 @@
         this.renderer = renderer;
         this.scene = scene;
         this.camera = camera;
-        this.composer = null;
+        this.composer = null; // Final composite pipeline
+        this.bloomComposer = null; // Isolated bloom render chain
         this.effects = {};
         this.enabled = false;
         
         // Layer management for selective bloom
         this.bloomLayer = new THREE.Layers();
         this.bloomLayer.set(1); // Layer 1 for blooming objects
-        this.darkMaterial = new THREE.MeshBasicMaterial({ color: 'black' });
-        this.materials = {};
+        this.hiddenObjects = new Map();
+        this.baseSize = new THREE.Vector2();
+        this.qualityCycle = ['low', 'medium', 'high'];
+        this.currentQualityScale = 1;
         
         console.log('PostProcessingManager: Initializing...');
         this.initialize();
@@ -1201,33 +1204,36 @@
        * Setup effect composer (Phase 2 - Implemented)
        */
       setupComposer() {
-        // Create EffectComposer for post-processing pipeline
+        // Base composer renders the full scene before compositing
         this.composer = new EffectComposer(this.renderer);
-        
-        // Add render pass (renders the scene)
         const renderPass = new RenderPass(this.scene, this.camera);
         this.composer.addPass(renderPass);
-        
-        // Store reference to render pass
         this.effects.renderPass = renderPass;
-        
-        console.log('PostProcessingManager: Composer initialized with RenderPass');
+
+        // Bloom composer isolates glowing objects for additive blend
+        this.bloomComposer = new EffectComposer(this.renderer);
+        this.bloomComposer.renderToScreen = false;
+        const bloomRenderPass = new RenderPass(this.scene, this.camera);
+        this.bloomComposer.addPass(bloomRenderPass);
+        this.effects.bloomRenderPass = bloomRenderPass;
+
+        this.updateComposerSizes(1);
+
+        console.log('PostProcessingManager: Composer pipeline initialized');
       }
       
       /**
        * Setup individual effects (Phase 2 - Bloom Implemented)
        */
       setupEffects() {
-        // Setup bloom if configured
-        if (CONFIG.visualEffects.bloom.enabled || true) { // Force setup for toggle capability
-          this.setupBloom();
-        }
+        // Setup bloom pipeline regardless of initial toggle so we can switch at runtime
+        this.setupBloom();
         
         // Add output pass for proper color space conversion
         const outputPass = new OutputPass();
         this.composer.addPass(outputPass);
         this.effects.outputPass = outputPass;
-        
+
         // Other effects will be added in Phase 3-4
         if (CONFIG.visualEffects.chromatic.enabled) {
           console.log('PostProcessingManager: Chromatic aberration configured (Phase 4)');
@@ -1240,6 +1246,9 @@
         if (CONFIG.visualEffects.customShaders.enabled) {
           console.log('PostProcessingManager: Custom shaders configured (Phase 3)');
         }
+
+        this.enabled = this.hasEnabledEffects();
+        this.applyQualityPreset();
       }
       
       /**
@@ -1248,26 +1257,56 @@
       setupBloom() {
         const params = CONFIG.visualEffects.bloom;
         
-        // Create bloom pass
+        // Create bloom pass operating on the secondary composer
         const bloomPass = new UnrealBloomPass(
           new THREE.Vector2(window.innerWidth, window.innerHeight),
           params.intensity,
           params.radius,
           params.threshold
         );
-        
-        // Configure bloom parameters
         bloomPass.threshold = params.threshold;
         bloomPass.strength = params.intensity;
         bloomPass.radius = params.radius;
-        
-        // Initially disable bloom
         bloomPass.enabled = params.enabled;
-        
-        // Add to composer
-        this.composer.addPass(bloomPass);
+
+        this.bloomComposer.addPass(bloomPass);
         this.effects.bloomPass = bloomPass;
-        
+
+        const compositePass = new ShaderPass(
+          new THREE.ShaderMaterial({
+            uniforms: {
+              baseTexture: { value: null },
+              bloomTexture: { value: null },
+              bloomStrength: { value: params.enabled ? 1 : 0 }
+            },
+            vertexShader: `
+              varying vec2 vUv;
+              void main() {
+                vUv = uv;
+                gl_Position = vec4(position.xy, 0.0, 1.0);
+              }
+            `,
+            fragmentShader: `
+              uniform sampler2D baseTexture;
+              uniform sampler2D bloomTexture;
+              uniform float bloomStrength;
+              varying vec2 vUv;
+              void main() {
+                vec4 base = texture2D(baseTexture, vUv);
+                vec4 bloom = texture2D(bloomTexture, vUv) * bloomStrength;
+                gl_FragColor = base + bloom;
+              }
+            `,
+            defines: {}
+          }),
+          'baseTexture'
+        );
+        compositePass.needsSwap = true;
+        this.composer.addPass(compositePass);
+        this.effects.compositePass = compositePass;
+
+        this.updateBloomTextureUniform();
+
         console.log('PostProcessingManager: Bloom pass configured', {
           intensity: params.intensity,
           radius: params.radius,
@@ -1275,7 +1314,7 @@
           enabled: params.enabled
         });
       }
-      
+
       /**
        * Prepare layers for selective bloom
        */
@@ -1293,6 +1332,7 @@
             // These layers will bloom
             layer.traverse((child) => {
               if (child.isMesh || child.isLine || child.isPoints) {
+                child.layers.enable(0);
                 child.layers.enable(1); // Enable bloom layer
                 console.log(`Enabled bloom for layer ${index}: ${layer.name}`);
               }
@@ -1309,6 +1349,68 @@
         
         console.log('PostProcessingManager: Layers prepared for selective bloom');
       }
+
+      /**
+       * Update bloom composite with the latest render target
+       */
+      updateBloomTextureUniform() {
+        if (!this.effects.compositePass || !this.bloomComposer) return;
+        const target = this.bloomComposer.renderTarget2;
+        if (target) {
+          this.effects.compositePass.material.uniforms.bloomTexture.value = target.texture;
+        }
+      }
+
+      /**
+       * Keep composer sizes in sync with the renderer and quality scale
+       */
+      updateComposerSizes(scale = 1, overrideWidth = null, overrideHeight = null) {
+        if (!this.composer || !this.bloomComposer) return;
+        let width = overrideWidth;
+        let height = overrideHeight;
+        if (width === null || height === null) {
+          this.renderer.getSize(this.baseSize);
+          width = this.baseSize.x;
+          height = this.baseSize.y;
+        } else {
+          this.baseSize.set(width, height);
+        }
+        this.composer.setSize(width, height);
+
+        const scaledWidth = Math.max(1, Math.round(width * scale));
+        const scaledHeight = Math.max(1, Math.round(height * scale));
+        this.bloomComposer.setSize(scaledWidth, scaledHeight);
+
+        if (this.effects.bloomPass && this.effects.bloomPass.resolution) {
+          this.effects.bloomPass.resolution.set(scaledWidth, scaledHeight);
+        }
+
+        this.updateBloomTextureUniform();
+      }
+
+      /**
+       * Temporarily hide non-bloom objects while rendering the bloom pass
+       */
+      hideNonBloomObjects() {
+        this.hiddenObjects.clear();
+        this.scene.traverse((object) => {
+          if (!object.isMesh && !object.isLine && !object.isPoints) return;
+          if (object.layers.test(this.bloomLayer)) return;
+          this.hiddenObjects.set(object.uuid, object.visible);
+          object.visible = false;
+        });
+      }
+
+      /**
+       * Restore visibility after bloom pass
+       */
+      restoreHiddenObjects() {
+        this.scene.traverse((object) => {
+          if (!this.hiddenObjects.has(object.uuid)) return;
+          object.visible = this.hiddenObjects.get(object.uuid);
+          this.hiddenObjects.delete(object.uuid);
+        });
+      }
       
       /**
        * Toggle effect by name
@@ -1318,6 +1420,9 @@
           // Toggle bloom effect
           CONFIG.visualEffects.bloom.enabled = !CONFIG.visualEffects.bloom.enabled;
           this.effects.bloomPass.enabled = CONFIG.visualEffects.bloom.enabled;
+          if (this.effects.compositePass) {
+            this.effects.compositePass.material.uniforms.bloomStrength.value = CONFIG.visualEffects.bloom.enabled ? 1 : 0;
+          }
           this.enabled = this.hasEnabledEffects();
           
           console.log(`PostProcessingManager: Bloom ${CONFIG.visualEffects.bloom.enabled ? 'enabled' : 'disabled'}`);
@@ -1377,39 +1482,57 @@
           console.warn(`PostProcessingManager: Invalid quality preset '${preset}'`);
         }
       }
+
+      /**
+       * Cycle through predefined quality presets
+       */
+      cycleQualityPreset() {
+        const currentIndex = this.qualityCycle.indexOf(CONFIG.visualEffects.qualityPreset);
+        const nextIndex = (currentIndex + 1) % this.qualityCycle.length;
+        const nextPreset = this.qualityCycle[nextIndex];
+        this.setQualityPreset(nextPreset);
+        return nextPreset;
+      }
       
       /**
        * Apply quality preset settings
        */
       applyQualityPreset() {
         const preset = CONFIG.visualEffects.qualityPreset;
-        
+        let scale = 1;
+
         switch (preset) {
           case 'low':
-            // Minimal effects for performance
-            this.setBloomIntensity(0.3);  // Reduced scale
-            this.setBloomRadius(0.1);     // Reduced scale
+            scale = 0.55;
+            this.setBloomIntensity(0.45);
+            this.setBloomRadius(0.12);
             console.log('PostProcessingManager: LOW quality preset applied');
             break;
           case 'medium':
-            // Balanced settings
-            this.setBloomIntensity(0.8);  // Matches new default
-            this.setBloomRadius(0.2);     // Matches new default
+            scale = 1.0;
+            this.setBloomIntensity(0.8);
+            this.setBloomRadius(0.2);
             console.log('PostProcessingManager: MEDIUM quality preset applied');
             break;
           case 'high':
-            // High quality
-            this.setBloomIntensity(1.2);  // Reduced scale
-            this.setBloomRadius(0.3);     // Reduced scale
+            scale = 1.25;
+            this.setBloomIntensity(1.1);
+            this.setBloomRadius(0.28);
             console.log('PostProcessingManager: HIGH quality preset applied');
             break;
           case 'ultra':
-            // Maximum quality
-            this.setBloomIntensity(1.5);  // Reduced scale
-            this.setBloomRadius(0.4);     // Reduced scale
+            scale = 1.35;
+            this.setBloomIntensity(1.4);
+            this.setBloomRadius(0.34);
             console.log('PostProcessingManager: ULTRA quality preset applied');
             break;
+          default:
+            console.warn(`PostProcessingManager: Unknown quality preset '${preset}'`);
+            break;
         }
+
+        this.currentQualityScale = scale;
+        this.updateComposerSizes(scale);
       }
       
       /**
@@ -1420,9 +1543,19 @@
           // No composer, use standard rendering
           return false;
         }
-        
-        // Always render through composer for consistent output
-        // Effects will be applied based on their enabled state
+
+        const bloomEnabled = CONFIG.visualEffects.bloom.enabled && this.effects.bloomPass;
+
+        if (bloomEnabled) {
+          this.hideNonBloomObjects();
+          this.bloomComposer.render(deltaTime);
+          this.restoreHiddenObjects();
+        }
+
+        if (this.effects.compositePass) {
+          this.effects.compositePass.material.uniforms.bloomStrength.value = bloomEnabled ? 1 : 0;
+        }
+
         this.composer.render(deltaTime);
         return true;
       }
@@ -1431,16 +1564,12 @@
        * Handle window resize
        */
       resize(width, height) {
-        if (this.composer) {
-          this.composer.setSize(width, height);
-          
-          // Update bloom pass resolution
-          if (this.effects.bloomPass) {
-            this.effects.bloomPass.resolution = new THREE.Vector2(width, height);
-          }
-          
-          console.log(`PostProcessingManager: Resized to ${width}x${height}`);
+        if (!this.composer) {
+          return;
         }
+
+        this.updateComposerSizes(this.currentQualityScale, width, height);
+        console.log(`PostProcessingManager: Resized to ${width}x${height}`);
       }
       
       /**
@@ -2235,12 +2364,17 @@
             console.log(`Main: Custom shaders ${enabled ? 'ENABLED' : 'DISABLED'}`);
           },
           'i': () => {
-            // Adjust shader intensity
-            if (this.shaderManager && CONFIG.visualEffects.customShaders.enabled) {
+            if (e.shiftKey && this.shaderManager && CONFIG.visualEffects.customShaders.enabled) {
               const currentIntensity = this.shaderManager.uniforms.energy?.intensity.value || 1;
               const newIntensity = currentIntensity >= 2 ? 0.5 : currentIntensity + 0.5;
               this.shaderManager.setIntensity(newIntensity);
               console.log(`Shader intensity: ${newIntensity}`);
+              return;
+            }
+
+            if (this.postProcessing) {
+              const nextPreset = this.postProcessing.cycleQualityPreset();
+              console.log(`Main: Bloom quality preset -> ${nextPreset.toUpperCase()}`);
             }
           }
         };

--- a/zeno-polyhedron-refactored.html
+++ b/zeno-polyhedron-refactored.html
@@ -1280,10 +1280,13 @@
               bloomStrength: { value: params.enabled ? 1 : 0 }
             },
             vertexShader: `
+              // For fullscreen quad rendering, set z=0.0 (on near plane) and w=1.0 (homogeneous coordinate)
+              #define FULLSCREEN_QUAD_Z 0.0
+              #define FULLSCREEN_QUAD_W 1.0
               varying vec2 vUv;
               void main() {
                 vUv = uv;
-                gl_Position = vec4(position.xy, 0.0, 1.0);
+                gl_Position = vec4(position.xy, FULLSCREEN_QUAD_Z, FULLSCREEN_QUAD_W);
               }
             `,
             fragmentShader: `

--- a/zeno-polyhedron-refactored.html
+++ b/zeno-polyhedron-refactored.html
@@ -1389,16 +1389,43 @@
       }
 
       /**
+       * Cache for non-bloom objects and dirty flag
+       */
+      _initNonBloomCache() {
+        this._nonBloomObjects = [];
+        this._nonBloomCacheDirty = true;
+      }
+
+      /**
+       * Mark the non-bloom object cache as dirty (call when scene changes)
+       */
+      markNonBloomCacheDirty() {
+        this._nonBloomCacheDirty = true;
+      }
+
+      /**
+       * Update the non-bloom object cache if dirty
+       */
+      _updateNonBloomCache() {
+        if (!this._nonBloomCacheDirty) return;
+        this._nonBloomObjects = [];
+        this.scene.traverse((object) => {
+          if ((!object.isMesh && !object.isLine && !object.isPoints) || object.layers.test(this.bloomLayer)) return;
+          this._nonBloomObjects.push(object);
+        });
+        this._nonBloomCacheDirty = false;
+      }
+
+      /**
        * Temporarily hide non-bloom objects while rendering the bloom pass
        */
       hideNonBloomObjects() {
         this.hiddenObjects.clear();
-        this.scene.traverse((object) => {
-          if (!object.isMesh && !object.isLine && !object.isPoints) return;
-          if (object.layers.test(this.bloomLayer)) return;
+        this._updateNonBloomCache();
+        for (const object of this._nonBloomObjects) {
           this.hiddenObjects.set(object.uuid, object.visible);
           object.visible = false;
-        });
+        }
       }
 
       /**

--- a/zeno-polyhedron-refactored.html
+++ b/zeno-polyhedron-refactored.html
@@ -1355,7 +1355,7 @@
        */
       updateBloomTextureUniform() {
         if (!this.effects.compositePass || !this.bloomComposer) return;
-        const target = this.bloomComposer.renderTarget2;
+        const target = this.bloomComposer.renderTarget2 || this.bloomComposer.renderTarget1;
         if (target) {
           this.effects.compositePass.material.uniforms.bloomTexture.value = target.texture;
         }


### PR DESCRIPTION
Implements layer-masked selective bloom so only the outer wireframes feed the UnrealBloomPass while the core stays crisp. The render pipeline now runs a dedicated bloom composer, hides non-bloom layers per frame, and composites the result back into the main pass with EffectComposer. Added keyboard controls for toggling bloom with B and cycling low/medium/high bloom quality with I (Shift+I still boosts shader intensity), plus resolution scaling for each preset.